### PR TITLE
Add table renderer and refactor to renderer files

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,18 @@
 
 ## Basic usage
 
-By default, the plugin looks for blog posts in a `posts` directory:
+First, ensure your blog posts are defined in the table of contents of your `myst.yml` file:
+
+```yaml
+project:
+  toc:
+    - pattern: posts/**/*.md
+```
+
+List the blog posts in a folder with the following directive:
 
 ```{myst:demo}
+% By default, the plugin looks for markdown files in a `posts` directory
 :::{blog-posts}
 :::
 ```
@@ -36,3 +45,40 @@ You can limit the number of posts displayed:
 :path: posts/**/*.md
 :::
 ```
+
+## Table view
+
+For blogs with many posts, you can use a more compact table layout instead of cards:
+
+```{myst:demo}
+:::{blog-posts}
+:kind: table
+:path: posts/**/*.md
+:::
+```
+
+By default, the table displays `title` and `date` columns. The title column is automatically linked to the post.
+
+## Custom table columns
+
+You can customize which frontmatter fields to display as columns using the `:table-columns:` option:
+
+```{myst:demo}
+:::{blog-posts}
+:kind: table
+:table-columns: title, date, subtitle
+:path: posts/**/*.md
+:::
+```
+
+Or reverse the date:
+
+```{myst:demo}
+:::{blog-posts}
+:kind: table
+:table-columns: date, title, subtitle
+:path: posts/**/*.md
+:::
+```
+
+Any frontmatter field can be used as a column!

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -9,7 +9,7 @@ project:
     - file: index.md
     - title: Posts
       children:
-        - pattern: posts/*.md
+        - pattern: posts/**/*.md
 site:
   template: book-theme
   options:

--- a/src/renderers/card.ts
+++ b/src/renderers/card.ts
@@ -1,0 +1,37 @@
+/**
+ * Renders blog posts as cards with title, subtitle, description, and date
+ */
+export function renderCards(posts: any[], ctx: any) {
+  return posts.map(post => {
+    const descriptionItems = post.frontmatter.description
+      ? ctx.parseMyst(post.frontmatter.description).children
+      : [];
+    const subtitleItems = post.frontmatter.subtitle
+      ? ctx.parseMyst(post.frontmatter.subtitle).children
+      : [];
+    const footerItems = post.frontmatter.date
+      ? [
+          {
+            type: "footer",
+            children: [
+              ctx.parseMyst(`**Date**: ${post.frontmatter.date}`)["children"][0],
+            ],
+          },
+        ]
+      : [];
+
+    return {
+      type: "card",
+      children: [
+        {
+          type: "cardTitle",
+          children: ctx.parseMyst(post.frontmatter.title).children,
+        },
+        ...subtitleItems,
+        ...descriptionItems,
+        ...footerItems,
+      ],
+      url: post.url,
+    };
+  });
+}

--- a/src/renderers/table.ts
+++ b/src/renderers/table.ts
@@ -1,0 +1,35 @@
+/**
+ * Renders blog posts as a table with configurable columns
+ */
+export function renderTable(posts: any[], columns: string[]) {
+  // Create header row
+  const headerRow = {
+    type: "tableRow",
+    children: columns.map(col => ({
+      type: "tableCell",
+      header: true,
+      children: [{ type: "text", value: col.charAt(0).toUpperCase() + col.slice(1) }],
+    })),
+  };
+
+  // Create data rows - table cells are plain text for simplicity
+  const dataRows = posts.map(post => ({
+    type: "tableRow",
+    children: columns.map(col => {
+      const value = post.frontmatter[col as keyof typeof post.frontmatter];
+      const textValue = value ? String(value) : "";
+
+      // Wrap title column in link
+      const content = col === "title"
+        ? [{ type: "link", url: post.url, children: [{ type: "text", value: textValue }] }]
+        : [{ type: "text", value: textValue }];
+
+      return { type: "tableCell", children: content };
+    }),
+  }));
+
+  return [{
+    type: "table",
+    children: [headerRow, ...dataRows],
+  }];
+}


### PR DESCRIPTION
This adds a little table renderer so that we can provide a more compact view of posts.

- closes #2 

It also does a minor refactor along the way so that the table and the card AST generation logic are in different places, and it's easier to track down where that code lives.

I am gonna make a v2 release so that I can confirm that all the build logic still works as expected via our Jupyter Book blog