### PR TITLE
Add simple sorting by metadata field

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ See the [documentation](https://jupyter-book.github.io/blog-plugin) for more usa
 
 - `docs/` - project documentation, written as a MyST site
 - `src/` - plugin source-code
+- `tests/` - `vitest` testing infrastructure
 - `noxfile.py` - several commands that we use to automate docs preview and building
 - `github` - workflows to build and publish this plugin to GitHub Pages and make releases.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A MyST plugin load blog posts from a file system and display them as a listing.
 
+> [!NOTE]
+> This is an experimental plugin developed for prototyping and use at [blog.jupyterbook.org](https://blog.jupyterbook.org).
+> The API may change and we don't promise stability yet. Use at your own risk!
+
 ## Basic usage
 
 See the [documentation](https://jupyter-book.github.io/blog-plugin) for more usage.

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,3 +82,33 @@ Or reverse the date:
 ```
 
 Any frontmatter field can be used as a column!
+
+## Sorting posts
+
+You can customize sorting with the `:sort:` option. This takes a form like:
+
+```
+:::{blog-posts]
+:sort: [column]-[asc/desc]
+:::
+```
+
+Where `[column]` is a field in each post's YAML metadata, and `asc/desc` corresponds to alphanumeric sort ascending or descending. Omitting the `-[asc/desc]` will default to `-asc`. For example:
+
+```{myst:demo}
+:::{blog-posts}
+:sort: title
+:kind: table
+:path: posts/**/*.md
+:::
+```
+
+```{myst:demo}
+:::{blog-posts}
+:sort: title-desc
+:kind: table
+:path: posts/**/*.md
+:::
+```
+
+Posts with missing values for the sort field are placed at the end.

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -17,9 +17,10 @@ const blogPostsDirective: DirectiveSpec = {
     "default-title": { type: String, doc: "Default title if none given." },
     kind: { type: String, doc: "Display style: 'card' or 'table'. Default is 'card'." },
     "table-columns": { type: String, doc: "Comma-separated list of frontmatter fields to display as table columns. Default is 'title,date'." },
+    sort: { type: String, doc: "Sort posts by field. Format: 'field-asc', 'field-desc', or just 'field' (defaults to asc). Default is 'date-desc'." },
   },
   run(data, vfile, ctx) {
-    const size = (data.options?.limit as number | undefined) ?? 3;
+    const size = (data.options?.limit as number | undefined) ?? 10;
     const searchPath = (data.options?.path as string | undefined) ?? "posts";
     const defaultTitle =
       (data.options?.["default-title"] as string | undefined) ??
@@ -34,10 +35,10 @@ const blogPostsDirective: DirectiveSpec = {
       ? searchPath
       : join(searchPath, "*.md");
 
-    const paths = globSync(searchPattern).sort().reverse(); // For now, string sort
+    const paths = globSync(searchPattern);
 
     // Collect post data from all files
-    const posts = paths.slice(0, size).map((path) => {
+    const posts = paths.map((path) => {
       const ext = extname(path);
       const content = readFileSync(path, { encoding: "utf-8" });
       const ast = ctx.parseMyst(content);
@@ -70,15 +71,40 @@ const blogPostsDirective: DirectiveSpec = {
       };
     });
 
+    // Sort posts (default: date-desc)
+    const sortOption = (data.options?.sort as string | undefined) ?? "date-desc";
+    const [field, order = 'asc'] = sortOption.split('-');
+    const ascending = order === 'asc';
+
+    posts.sort((a, b) => {
+      const aValue = a.frontmatter[field as keyof typeof a.frontmatter];
+      const bValue = b.frontmatter[field as keyof typeof b.frontmatter];
+
+      // Empty values go at the end
+      if (!aValue && !bValue) return 0;
+      if (!aValue) return 1;
+      if (!bValue) return -1;
+
+      // Alphanumeric comparison
+      const aStr = String(aValue);
+      const bStr = String(bValue);
+      const comparison = aStr.localeCompare(bStr, undefined, { numeric: true });
+
+      return ascending ? comparison : -comparison;
+    });
+
+    // Apply limit after sorting
+    const limitedPosts = posts.slice(0, size);
+
     // Render as table or cards based on kind
     if (kind === "table") {
       const tableColumns = ((data.options?.["table-columns"] as string | undefined) ?? "title,date")
         .split(",")
         .map(c => c.trim())
         .filter(c => c.length > 0);
-      return renderTable(posts, tableColumns);
+      return renderTable(limitedPosts, tableColumns);
     } else {
-      return renderCards(posts, ctx);
+      return renderCards(limitedPosts, ctx);
     }
   },
 };

--- a/tests/renderers.test.ts
+++ b/tests/renderers.test.ts
@@ -27,4 +27,27 @@ describe('blog-posts plugin', () => {
     expect(nodes.some((n: any) => n.type === 'card')).toBe(true);
     expect(nodes.some((n: any) => n.type === 'table')).toBe(true);
   });
+
+  it('sorts posts by title', () => {
+    const ast = JSON.parse(readFileSync(buildPath, 'utf-8')).mdast;
+    const tables = findBlogPostNodes(ast).filter((n: any) => n.type === 'table');
+
+    expect(tables.length).toBeGreaterThan(0);
+
+    // Find a table and extract titles
+    const getTitles = (table: any) => table.children
+      .slice(1) // Skip header row
+      .map((row: any) => row.children[0].children[0].children[0].value);
+
+    // Last two tables should be the sort examples (title asc, title desc)
+    const lastTwoTables = tables.slice(-2);
+    expect(lastTwoTables.length).toBe(2);
+
+    const ascTitles = getTitles(lastTwoTables[0]);
+    const descTitles = getTitles(lastTwoTables[1]);
+
+    // Verify they're sorted
+    expect(ascTitles).toEqual([...ascTitles].sort());
+    expect(descTitles).toEqual([...descTitles].sort().reverse());
+  });
 });


### PR DESCRIPTION
This adds a simple sorting functionality `[field]-[asc/desc]` and a little test for it.

I haven't closely inspected the sorting algorithm for edge cases etc, but I added a test and figure we can catch those in the future. I think it's OK since this is a one-off repo right now.